### PR TITLE
Import `quote` from scheme.base before other libraries

### DIFF
--- a/bytestructures.meta
+++ b/bytestructures.meta
@@ -5,7 +5,7 @@
  (synopsis "Structured access to bytevector contents")
  (license "GPL-3")
  (category data)
- (depends (r7rs "0.0.5")
+ (depends (r7rs "0.0.6")
           (r6rs-bytevectors "1.0.2")
           srfi-60
           format

--- a/chicken/bytestructures.sld
+++ b/chicken/bytestructures.sld
@@ -1,4 +1,5 @@
 (define-library (bytestructures)
+  (import (only (scheme base) quote))
   (import
    (bytestructures base)
    (bytestructures vector)

--- a/chicken/bytevectors.sld
+++ b/chicken/bytevectors.sld
@@ -1,4 +1,5 @@
 (define-library (bytestructures bytevectors)
+  (import (only (scheme base) quote))
   (cond-expand
    ((library (rnrs bytevectors))
     (import (except (rnrs bytevectors)

--- a/chicken/numeric-metadata.sld
+++ b/chicken/numeric-metadata.sld
@@ -1,3 +1,4 @@
 (define-library (bytestructures numeric-metadata)
+  (import (only (scheme base) quote))
   (import (bytestructures numeric-all))
   (include-library-declarations "r7/numeric-metadata.exports.sld"))

--- a/chicken/numeric.sld
+++ b/chicken/numeric.sld
@@ -1,3 +1,4 @@
 (define-library (bytestructures numeric)
+  (import (only (scheme base) quote))
   (import (bytestructures numeric-all))
   (include-library-declarations "r7/numeric.exports.sld"))


### PR DESCRIPTION
Hi John,

This fixes, or rather works around, #1403. Basically, in fixing the last issue you reported against r7rs (the one described in f969f3b), we've uncovered a bug in core that I can't fix directly in the egg. [This][1] is the bug, and working around it is a matter of importing `quote` as necessary.

[1]: https://lists.nongnu.org/archive/html/chicken-hackers/2017-12/msg00048.html